### PR TITLE
Upload provenance report as artifact for CLI access

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -126,3 +126,10 @@ jobs:
           git commit -m "Update signalsets from OBDb repositories [skip ci]"
           git push
           echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Upload provenance report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: provenance-report
+          path: |
+            build/signal_provenance_report.md
+            build/signal_provenance_report.json


### PR DESCRIPTION
This PR adds an artifact upload step for the provenance report in the daily-update workflow, making it accessible via GitHub CLI.

The changes:
- Add artifact upload step to capture provenance report (markdown and JSON)
- Remove raw JSON dump section from workflow summary (no longer needed when using artifacts)

This allows downstream tools and CLI utilities to access the provenance data without cluttering the workflow summary.